### PR TITLE
[Feat] #20 - DataManager 보류, 공연 상세 정보 호출 기능 구현

### DIFF
--- a/MaDang/MaDang.xcodeproj/project.pbxproj
+++ b/MaDang/MaDang.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		33388DF62C720F3300DECDC3 /* GPTManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DF52C720F3300DECDC3 /* GPTManager.swift */; };
 		33388DF92C720F5700DECDC3 /* ChatGPTSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 33388DF82C720F5700DECDC3 /* ChatGPTSwift */; };
 		33388DFB2C720F5700DECDC3 /* SampleApp in Frameworks */ = {isa = PBXBuildFile; productRef = 33388DFA2C720F5700DECDC3 /* SampleApp */; };
+		33388DFD2C72149E00DECDC3 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DFC2C72149E00DECDC3 /* DataManager.swift */; };
+		33388DFF2C7226D900DECDC3 /* DetailXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -81,6 +83,8 @@
 		33388DEA2C713C6900DECDC3 /* ApiModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiModel.swift; sourceTree = "<group>"; };
 		33388DEC2C713E5C00DECDC3 /* XMLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLParser.swift; sourceTree = "<group>"; };
 		33388DF52C720F3300DECDC3 /* GPTManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTManager.swift; sourceTree = "<group>"; };
+		33388DFC2C72149E00DECDC3 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
+		33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailXMLParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +173,7 @@
 				33388D902C6F635300DECDC3 /* Color+.swift */,
 				33388DE52C71305B00DECDC3 /* Constants.swift */,
 				33388DEC2C713E5C00DECDC3 /* XMLParser.swift */,
+				33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -238,6 +243,7 @@
 			children = (
 				33388DE12C712E3800DECDC3 /* KopisNetworkingManager.swift */,
 				33388DF52C720F3300DECDC3 /* GPTManager.swift */,
+				33388DFC2C72149E00DECDC3 /* DataManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -320,6 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33388D722C6F2C0A00DECDC3 /* ContentView.swift in Sources */,
+				33388DFD2C72149E00DECDC3 /* DataManager.swift in Sources */,
 				33388DE92C71324100DECDC3 /* Bundle+.swift in Sources */,
 				33388DBD2C7085C300DECDC3 /* MainView.swift in Sources */,
 				33388DC52C70867500DECDC3 /* BestReviewView.swift in Sources */,
@@ -329,6 +336,7 @@
 				33388D8B2C6F367300DECDC3 /* DetailReviewView.swift in Sources */,
 				33388D982C6F8E2800DECDC3 /* Actor.swift in Sources */,
 				33388D9A2C6F8EC000DECDC3 /* Review.swift in Sources */,
+				33388DFF2C7226D900DECDC3 /* DetailXMLParser.swift in Sources */,
 				33388D9E2C6F906B00DECDC3 /* User.swift in Sources */,
 				33388DDD2C70FC6200DECDC3 /* GenreModalView.swift in Sources */,
 				33388DC32C70866600DECDC3 /* GenreView.swift in Sources */,

--- a/MaDang/MaDang/Helper/Constants.swift
+++ b/MaDang/MaDang/Helper/Constants.swift
@@ -27,5 +27,6 @@ public struct PerformList {
     static let openrun = "openrun" // 오픈런, Y/N
     static let newsql = "newsql" // 최신 공연 순, Y/N
     
+    
     private init(){}
 }

--- a/MaDang/MaDang/Helper/DetailXMLParser.swift
+++ b/MaDang/MaDang/Helper/DetailXMLParser.swift
@@ -1,0 +1,103 @@
+//
+//  DetailXMLParser.swift
+//  MaDang
+//
+//  Created by LDW on 8/18/24.
+//
+
+import Foundation
+
+final class DetailXMLParser : NSObject, XMLParserDelegate {
+    private var detailDB: DetailDB?
+    private var currentValue: String = ""
+    private var imageUrls: [String] = []
+    private var relatedLinks: [DetailDbs] = []
+    
+    // 날짜 변환을 위한 DateFormatter
+    let dateFormatter = DateFormatter()
+    
+    // XMLParserDelegate 메서드 중 시작 태그를 만났을 때 호출되는 메서드
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+        currentValue = ""
+        
+        if elementName == "db" {
+            detailDB = DetailDB(
+                id: "", title: "", genre: "", startDate: "", endDate: "", venue: "",
+                cast: [], crew: [], runtime: "", ageLimit: "", company: "", ticketPrice: "", posterUrl: "",
+                imageUrls: [], area: "", performanceStatus: "", showtimes: "", relatedLinks: []
+            )
+        }
+    }
+    
+    // XMLParserDelegate 메서드 중 태그의 텍스트를 만났을 때 호출되는 메서드
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        currentValue += string.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    // XMLParserDelegate 메서드 중 종료 태그를 만났을 때 호출되는 메서드
+    func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+        guard var detailDB = detailDB else { return }
+        
+        switch elementName {
+        case "mt20id":
+            self.detailDB?.id = currentValue
+        case "prfnm":
+            self.detailDB?.title = currentValue
+        case "prfpdfrom":
+            self.detailDB?.startDate = currentValue
+        case "prfpdto":
+            self.detailDB?.endDate = currentValue
+        case "fcltynm":
+            self.detailDB?.venue = currentValue
+        case "prfcast":
+            self.detailDB?.cast = currentValue.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        case "prfcrew":
+            detailDB.crew = currentValue.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        case "prfruntime":
+            self.detailDB?.runtime = currentValue
+        case "prfage":
+            self.detailDB?.ageLimit = currentValue
+        case "entrpsnm":
+            self.detailDB?.company = currentValue
+        case "pcseguidance":
+            self.detailDB?.ticketPrice = currentValue
+        case "poster":
+            self.detailDB?.posterUrl = currentValue
+        case "styurl":
+            imageUrls.append(currentValue)
+        case "area":
+            self.detailDB?.area = currentValue
+        case "prfstate":
+            self.detailDB?.performanceStatus = currentValue
+        case "dtguidance":
+            self.detailDB?.showtimes = currentValue
+        case "relatenm":
+            let relatedLink = DetailDbs(name: currentValue, url: "")
+            relatedLinks.append(relatedLink)
+        case "relateurl":
+            if let lastIndex = relatedLinks.indices.last {
+                relatedLinks[lastIndex].url = currentValue
+            }
+        case "db":
+            self.detailDB?.imageUrls = imageUrls
+            self.detailDB?.relatedLinks = relatedLinks
+            self.detailDB = detailDB
+        default:
+            break
+        }
+        
+        currentValue = ""
+    }
+    
+    // 파싱이 완료되었을 때 호출되는 메서드 (테스트용)
+    func parserDidEndDocument(_ parser: XMLParser) {
+        if let detailDB = detailDB {
+            print("DetailDB: \(detailDB)")
+        }
+    }
+    
+    // 파싱된 데이터를 반환하는 메서드
+    func getParsedData() -> DetailDB? {
+        return detailDB
+    }
+}

--- a/MaDang/MaDang/Helper/XMLParser.swift
+++ b/MaDang/MaDang/Helper/XMLParser.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// MARK: - PerformList parser
 final class MyXMLParser: NSObject, XMLParserDelegate {
     private var currentElement: String?
     private var currentDB: DB?

--- a/MaDang/MaDang/Manager/DataManager.swift
+++ b/MaDang/MaDang/Manager/DataManager.swift
@@ -1,0 +1,31 @@
+//
+//  DataManager.swift
+//  MaDang
+//
+//  Created by LDW on 8/18/24.
+//
+
+import Foundation
+
+
+// 없는게 편할 거 같기도 ? ? 보류
+final class DataManager: ObservableObject {
+    
+    static let shared = DataManager()
+    private init() {}
+    
+    // 필터링을 통해서
+    // - 최신 공연 4개 이미지
+    // - 장르별 공연 9개 이미지 추출 후 보여주기
+    @Published var performs: [Performance] = []
+    
+    // 뇌피셜, 인기 순위 이미지는 파이어베이스에서 정렬되서 나오니, 아에 분리하는게 나을수도 있겠다..?
+    @Published var popularPerforms: [Performance] = []
+    
+    
+    // 번역 메서드
+    func translationInfo() {}
+    
+
+    
+}

--- a/MaDang/MaDang/Manager/KopisNetworkingManager.swift
+++ b/MaDang/MaDang/Manager/KopisNetworkingManager.swift
@@ -29,6 +29,7 @@ final class KopisNetworkingManager {
     private init() {}
     
     typealias PerformListNetworkCompletion = (Result<[Performance], NetworkError>) -> Void
+    typealias PerformNetworkCompletion = (Result<Performance, NetworkError>) -> Void
     
     // Date 변환을 위한 DateFormatter 설정
     let dateFormatter: DateFormatter = {
@@ -37,6 +38,7 @@ final class KopisNetworkingManager {
         return formatter
     }()
     
+    // MARK: - PerfromList 요청
     // MARK: - URL 생성 후 request 실행
     func fetchPerformList(startDate: String, endDate: String, row: Int, genreCode: String, completion: @escaping PerformListNetworkCompletion) {
         guard let key = Bundle.main.apiKey else {
@@ -73,17 +75,17 @@ final class KopisNetworkingManager {
             }
             
             //XML parsing
-            if let performs = self.parsePerformListXML(safeData) {
-                completion(.success(performs))
-            } else {
-                completion(.failure(.parseError))
-            }
+//            if let performs = self.parsePerformXML(safeData) {
+//                completion(.success(performs))
+//            } else {
+//                completion(.failure(.parseError))
+//            }
         }
         task.resume()
     }
     
     // MARK: - MyXMLParser 객체를 이용해서 XML 파싱
-    private func parsePerformListXML(_ performData: Data) -> [Performance]? {
+    private func parsePerformListXML(_ performData: Data) -> Performance? {
         var dbs: [DB] = []
         let parser = XMLParser(data: performData)
         let myParser = MyXMLParser()
@@ -96,8 +98,75 @@ final class KopisNetworkingManager {
             
             // 여기서 DTO -> entity 변환
             // 그리고 [DB]?가 아닌 [Performance]?를 반환하도록
-            if let performs = convertDBArrayToPerformanceArray(dbs) {
-                return performs
+//            if let performs = convertDBArrayToPerformanceArray(dbs) {
+//                return performs
+//            }
+        }
+        return nil
+    }
+    
+    // MARK: - 하나의 공연에 대해 요청
+    // MARK: - URL 생성 후 request 실행
+    func fetchPerform(id: String, completion: @escaping PerformNetworkCompletion) {
+        guard let key = Bundle.main.apiKey else {
+            print("No KOPIS_API_KEY")
+            return
+        }
+        
+        let urlString = "\(PerformList.requestUrl)/\(id)\(PerformList.service)=\(key)&\(PerformList.newsql)=Y"
+   
+        print("\(urlString)")
+        
+        performPerformRequest(with: urlString) { result in
+            completion(result)
+        }
+    }
+    
+    // MARK: - URLSession을 이용해 request 후 XML parsing
+    func performPerformRequest(with urlString: String, completion: @escaping PerformNetworkCompletion) {
+        guard let url = URL(string: urlString) else { return }
+        
+        let session = URLSession(configuration: .default)
+        // Networking task (비동기 처리)
+        let task = session.dataTask(with: url) { (data, response, error) in
+            if error != nil {
+                print(error!)
+                completion(.failure(.networkingError))
+                return
+            }
+            
+            // response data 옵셔널 바인딩
+            guard let safeData = data else {
+                completion(.failure(.dataError))
+                return
+            }
+            
+            //XML parsing
+            if let performs = self.parsePerformXML(safeData) {
+                completion(.success(performs))
+            } else {
+                completion(.failure(.parseError))
+            }
+        }
+        task.resume()
+    }
+    
+    // MARK: - MyXMLParser 객체를 이용해서 XML 파싱
+    private func parsePerformXML(_ performData: Data) -> Performance? {
+        var detailDB: DetailDB?
+        let parser = XMLParser(data: performData)
+        let myParser = DetailXMLParser()
+        parser.delegate = myParser
+        
+        if parser.parse() {
+            if let parsedData = myParser.getParsedData() {
+                detailDB = parsedData // 파싱된 DB 배열을 반환
+            }
+            
+            // 여기서 DTO -> entity 변환
+            // 그리고 [DB]?가 아닌 [Performance]?를 반환하도록
+            if let perform = convertDetailDBtoPerformance(detailDB) {
+                return perform
             }
         }
         return nil
@@ -105,11 +174,14 @@ final class KopisNetworkingManager {
 }
 
 extension KopisNetworkingManager {
-
     func convertStringToDate(_ dateString: String) -> Date {
         return dateFormatter.date(from: dateString) ?? Date() // 기본 값은 현재 날짜
     }
-
+    
+    func findGenre(from genrenm: String) -> Genre {
+        return Genre(rawValue: genrenm) ?? .All
+    }
+    
     // [DB]? 배열을 [Performance]? 배열로 변환하는 함수
     func convertDBArrayToPerformanceArray(_ dbArray: [DB]?) -> [Performance]? {
         guard let dbArray = dbArray else { return nil }
@@ -134,9 +206,20 @@ extension KopisNetworkingManager {
         return performances
     }
     
-    func findGenre(from genrenm: String) -> Genre {
-        return Genre(rawValue: genrenm) ?? .All
+    // MARK: - DetailDB to Performance
+    func convertDetailDBtoPerformance(_ detailDB: DetailDB?) -> Performance? {
+        guard let detailDB = detailDB else { return nil}
+        
+        return Performance(id: detailDB.id,
+                           title: detailDB.title,
+                           genre: findGenre(from: detailDB.genre),
+                           startDate: convertStringToDate(detailDB.startDate),
+                           endDate: convertStringToDate(detailDB.endDate),
+                           showtime: detailDB.runtime,
+                           ageLimit: detailDB.ageLimit,
+                           salesVolume: 0,
+                           posterUrlList: detailDB.imageUrls,
+                           reviewList: [],
+                           actorList: [])
     }
-    
-
 }

--- a/MaDang/MaDang/Model/ApiModel.swift
+++ b/MaDang/MaDang/Model/ApiModel.swift
@@ -26,4 +26,30 @@ struct DB {
     var area, genrenm, openrun, prfstate: String
 }
 
-// MARK: - 장르 코드
+
+struct DetailDB {
+    var id: String
+    var title: String
+    var genre: String
+    var startDate: String
+    var endDate: String
+    var venue: String
+    var cast: [String]
+    var crew: [String]
+    var runtime: String
+    var ageLimit: String
+    var company: String
+    var ticketPrice: String
+    var posterUrl: String
+    var imageUrls: [String]
+    var area: String
+    var performanceStatus: String
+    var showtimes: String
+    var relatedLinks: [DetailDbs]
+}
+
+struct DetailDbs {
+    var name: String
+    var url: String
+}
+

--- a/MaDang/MaDang/View/ContentView.swift
+++ b/MaDang/MaDang/View/ContentView.swift
@@ -40,6 +40,29 @@ struct ContentView: View {
             }, label: {
                 Text("Button")
             })
+            
+            Button(action: {
+                shared.fetchPerform(id: "PF132236") { result in
+                    switch result {
+                    case .success(let perform) :
+                        print("success")
+                        print("-----------------------------")
+                        print(" perform id :\(perform.id)")
+                        print(" perform title :\(perform.title)")
+                        print(" perform genre : \(perform.genre)")
+                        print(" perform startdate : \(perform.startDate)")
+                        print("-----------------------------")
+                        
+
+                    case .failure(_):
+                         print("failure")
+                     }
+                 }
+
+            }, label: {
+                Text("Button")
+            })
+            
         }
         .padding()
     }


### PR DESCRIPTION
 DataManager 보류, 공연 상세 정보 호출 기능 구현

- DataManager가 있으면 뒤에서 정보처리가 편할 거 같아서 구현하려 했는데,
  막상 진행하다보니 애매한 것 같아서 보류, 화면 연동해보면서 필요를 고민해볼듯

- 이전 공연 목록 데이터를 호출해서 [Performance]로 return 하는 메서드 구현
- 이어서 공연 상세 데이터를 호출해서 Performance로 return 하는 메서드 구현
- 위 Performance 데이터들을 기준으로 MainView에 연동해볼 예정