### PR TITLE
[Design] #22 - Main, Detail 일부 데이터 연동 및 오류 수정

### DIFF
--- a/MaDang/MaDang/App/MaDangApp.swift
+++ b/MaDang/MaDang/App/MaDangApp.swift
@@ -9,9 +9,14 @@ import SwiftUI
 
 @main
 struct MaDangApp: App {
+    init() {
+        DataManager.shared.fetchData()
+    }
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            //ContentView()
+            MainView()
         }
     }
 }

--- a/MaDang/MaDang/App/MaDangApp.swift
+++ b/MaDang/MaDang/App/MaDangApp.swift
@@ -9,14 +9,9 @@ import SwiftUI
 
 @main
 struct MaDangApp: App {
-    init() {
-        DataManager.shared.fetchData()
-    }
-    
     var body: some Scene {
         WindowGroup {
-            //ContentView()
-            MainView()
+            MainTabView()
         }
     }
 }

--- a/MaDang/MaDang/Helper/XMLParser.swift
+++ b/MaDang/MaDang/Helper/XMLParser.swift
@@ -46,6 +46,7 @@ final class MyXMLParser: NSObject, XMLParserDelegate {
         case "fcltynm":
             self.currentDB?.fcltynm = currentValue
         case "poster":
+            currentValue = convertToHTTPS(urlString: currentValue)
             self.currentDB?.poster = currentValue
         case "area":
             self.currentDB?.area = currentValue
@@ -97,5 +98,12 @@ final class MyXMLParser: NSObject, XMLParserDelegate {
     // 파싱된 데이터를 반환하는 메서드
     func getParsedData() -> Welcome4? {
         return welcome4
+    }
+    
+    func convertToHTTPS(urlString: String) -> String {
+        if urlString.lowercased().hasPrefix("http://") {
+            return urlString.replacingOccurrences(of: "http://", with: "https://")
+        }
+        return urlString
     }
 }

--- a/MaDang/MaDang/Manager/DataManager.swift
+++ b/MaDang/MaDang/Manager/DataManager.swift
@@ -22,10 +22,22 @@ final class DataManager: ObservableObject {
     // 뇌피셜, 인기 순위 이미지는 파이어베이스에서 정렬되서 나오니, 아에 분리하는게 나을수도 있겠다..?
     @Published var popularPerforms: [Performance] = []
     
+    var filteredPerforms: [Performance] {
+           Array(performs.prefix(4))
+    }
     
-    // 번역 메서드
-    func translationInfo() {}
-    
+    // 데이터 요청
+    func fetchData() {
+        let network = KopisNetworkingManager.shared
+        // 임의 조건 설정
+        network.fetchPerformList(startDate: "20240801", endDate: "20240831", row: 10, genreCode: "AAAA") { result in
+            switch result {
+            case .success(let performs):
+                self.performs = performs
+            case .failure(_):
+                print("failure")
+            }
+        }
+    }
 
-    
 }

--- a/MaDang/MaDang/Manager/KopisNetworkingManager.swift
+++ b/MaDang/MaDang/Manager/KopisNetworkingManager.swift
@@ -173,6 +173,7 @@ extension KopisNetworkingManager {
         }
         return nil
     }
+    
 }
 
 extension KopisNetworkingManager {
@@ -213,7 +214,6 @@ extension KopisNetworkingManager {
     // MARK: - DetailDB to Performance
     func convertDetailDBtoPerformance(_ detailDB: DetailDB?) -> Performance? {
         guard let detailDB = detailDB else { return nil}
-        
         return Performance(id: detailDB.id,
                            title: detailDB.title,
                            genre: findGenre(from: detailDB.genre),
@@ -229,4 +229,6 @@ extension KopisNetworkingManager {
                            starRating: 0
         )
     }
+    
+
 }

--- a/MaDang/MaDang/Manager/KopisNetworkingManager.swift
+++ b/MaDang/MaDang/Manager/KopisNetworkingManager.swift
@@ -47,7 +47,7 @@ final class KopisNetworkingManager {
         }
         
         let urlString = "\(PerformList.requestUrl)\(PerformList.service)=\(key)&\(PerformList.stdate)=\(startDate)&\(PerformList.eddate)=\(endDate)&cpage=1&\(PerformList.rows)=\(row)&\(PerformList.shcate)=\(genreCode)&\(PerformList.newsql)=Y"
-   
+        
         print("\(urlString)")
         
         performPerformListRequest(with: urlString) { result in
@@ -75,17 +75,17 @@ final class KopisNetworkingManager {
             }
             
             //XML parsing
-//            if let performs = self.parsePerformXML(safeData) {
-//                completion(.success(performs))
-//            } else {
-//                completion(.failure(.parseError))
-//            }
+            if let performs = self.parsePerformListXML(safeData) {
+                completion(.success(performs))
+            } else {
+                completion(.failure(.parseError))
+            }
         }
         task.resume()
     }
     
     // MARK: - MyXMLParser 객체를 이용해서 XML 파싱
-    private func parsePerformListXML(_ performData: Data) -> Performance? {
+    private func parsePerformListXML(_ performData: Data) -> [Performance]? {
         var dbs: [DB] = []
         let parser = XMLParser(data: performData)
         let myParser = MyXMLParser()
@@ -98,14 +98,16 @@ final class KopisNetworkingManager {
             
             // 여기서 DTO -> entity 변환
             // 그리고 [DB]?가 아닌 [Performance]?를 반환하도록
-//            if let performs = convertDBArrayToPerformanceArray(dbs) {
-//                return performs
-//            }
+            if let performs = convertDBArrayToPerformanceArray(dbs) {
+                return performs
+            }
         }
         return nil
     }
-    
-    // MARK: - 하나의 공연에 대해 요청
+}
+
+// MARK: - 하나의 공연에 대해 요청
+extension KopisNetworkingManager {
     // MARK: - URL 생성 후 request 실행
     func fetchPerform(id: String, completion: @escaping PerformNetworkCompletion) {
         guard let key = Bundle.main.apiKey else {

--- a/MaDang/MaDang/View/DetailView/DetailCastingView.swift
+++ b/MaDang/MaDang/View/DetailView/DetailCastingView.swift
@@ -16,6 +16,7 @@ struct DetailCastingView: View {
         GridItem(.flexible()),
         GridItem(.flexible())
     ]
+    @Binding var perform: Performance
     
     var body: some View {
         VStack {
@@ -58,5 +59,5 @@ struct DetailCastingView: View {
 }
 
 #Preview {
-    DetailCastingView(numberOfCircles: 7)
+    DetailCastingView(numberOfCircles: 7, perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/DetailView/DetailImageView.swift
+++ b/MaDang/MaDang/View/DetailView/DetailImageView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct DetailImageView: View {
     @State private var showMoreImages = false
+    @Binding var perform: Performance
     
     var body: some View {
         ScrollView {
@@ -68,13 +69,18 @@ struct DetailImageView: View {
 
                 if showMoreImages {
                     VStack(spacing: 0) {
-                        Image("kopisTestImage")
-                            .resizable()
-                            .scaledToFit()
-                        
-                        Image("kopisTestImage")
-                            .resizable()
-                            .scaledToFit()
+                        ForEach(perform.posterUrlList.indices, id: \.self) { index in
+                            if !(index == 0) && !(index == 1) {
+                                AsyncImage(url: URL(string: perform.posterUrlList[index])) { image in
+                                    image
+                                        .resizable()
+                                        .scaledToFit()
+                                        .frame(maxWidth: .infinity)
+                                } placeholder: {
+                                    Color.gray
+                                }
+                            }
+                        }
                         
                         
                         Button(action: {
@@ -111,5 +117,5 @@ struct DetailImageView: View {
 }
 
 #Preview {
-    DetailImageView()
+    DetailImageView(perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/DetailView/DetailInfoView.swift
+++ b/MaDang/MaDang/View/DetailView/DetailInfoView.swift
@@ -8,15 +8,24 @@
 import SwiftUI
 
 struct DetailInfoView: View {
+    @Binding var perform: Performance
+    
     var body: some View {
             VStack(alignment: .leading) {
-                Image("kopisTestImage")
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(maxWidth: .infinity) // 화면 너비에 맞추기
-                                    .background(.nineBlack)
                 
-                Text("A Store Selling Time")
+                let url = perform.posterUrlList.isEmpty ? "" : perform.posterUrlList[0]
+                
+                AsyncImage(url: URL(string: url)) { image in
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                } placeholder: {
+                    Color.gray
+                }
+                
+                
+                Text("\(perform.title)")
                     .fontWeight(.bold)
                     .font(.system(size: 28))
                     .foregroundStyle(.white)
@@ -33,7 +42,7 @@ struct DetailInfoView: View {
                             .stroke(.nineYellow, lineWidth: 2)
                     )
                 
-                Text("Bupyeong Arts Center Dalnuri Theater")
+                Text("\(perform.area)")
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
                     .padding(.leading, 10)
@@ -56,7 +65,7 @@ struct DetailInfoView: View {
                             .stroke(.nineYellow, lineWidth: 2)
                     )
                 
-                Text("Oct. 4, 2024(Fri.) ~ Oct. 19, 2024(Sat.)")
+                Text("\(perform.startDate) ~ \(perform.endDate)")
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
                     .padding(.leading, 10)
@@ -79,7 +88,7 @@ struct DetailInfoView: View {
                             .stroke(.nineYellow, lineWidth: 2)
                     )
                 
-                Text("Fri. 19:30 / Sat. 18:00")
+                Text("\(perform.showtime)")
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
                     .padding(.leading, 10)
@@ -102,7 +111,7 @@ struct DetailInfoView: View {
                             .stroke(.nineYellow, lineWidth: 2)
                     )
                 
-                Text("Suitable for ages 7 and older")
+                Text("\(perform.ageLimit)")
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
                     .padding(.leading, 10)
@@ -125,7 +134,7 @@ struct DetailInfoView: View {
                             .stroke(.nineYellow, lineWidth: 2)
                     )
                 
-                Text("All seats ₩30,000 / $21.99")
+                Text("삭제 예정")
                     .font(.system(size: 14))
                     .foregroundStyle(.white)
                     .padding(.leading, 10)
@@ -138,5 +147,5 @@ struct DetailInfoView: View {
 
 
 #Preview {
-    DetailInfoView()
+    DetailInfoView(perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/DetailView/DetailReviewView.swift
+++ b/MaDang/MaDang/View/DetailView/DetailReviewView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct DetailReviewView: View {
+    @Binding var perform: Performance
+    
     var body: some View {
         VStack{
             HStack {
@@ -240,5 +242,5 @@ struct DetailReviewView: View {
 }
 
 #Preview {
-    DetailReviewView()
+    DetailReviewView(perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/DetailView/DetailView.swift
+++ b/MaDang/MaDang/View/DetailView/DetailView.swift
@@ -8,18 +8,21 @@
 import SwiftUI
 
 struct DetailView: View {
+    
+    @Binding var perform: Performance
+    
     var body: some View {
         ScrollView {
-                DetailInfoView()
+            DetailInfoView(perform: $perform)
                 .padding(.bottom, 96)
-                DetailImageView()
-                DetailReviewView()
-                DetailCastingView(numberOfCircles: 7)
+            DetailImageView(perform: $perform)
+            DetailReviewView(perform: $perform)
+            DetailCastingView(numberOfCircles: 7, perform: $perform)
         }
         .background(.nineBlack)
     }
 }
 
 #Preview {
-    DetailView()
+    DetailView(perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/MainView/GenreView.swift
+++ b/MaDang/MaDang/View/MainView/GenreView.swift
@@ -11,15 +11,19 @@ struct GenreView: View {
     
     @State private var isModalPresented: Bool = false
     @Binding var currentGenre: Genre
-    @State private var performs: [Performance] = Performance.performList
+    @Binding var performs: [Performance]
     
     var body: some View {
         
-        let filteredPerforms = performs.filter { per in
-            if currentGenre == .All {return true}
-            return per.genre == currentGenre
-        }
-        .prefix(9)
+        let filteredPerforms = performs
+//            
+//            .filter { per in
+////            if currentGenre == .All {return true}
+////            return per.genre == currentGenre
+//              return true
+//        }
+//        .prefix(9)
+        
         
         let columns = Array(repeating: GridItem(.flexible()), count: 3)
         
@@ -59,9 +63,25 @@ struct GenreView: View {
                 LazyVGrid(columns: columns, spacing: 8) {
                     ForEach(filteredPerforms, id: \.id) { perform in
                         ZStack {
-                            Image("kopisTestImage")
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
+//                            Image("kopisTestImage")
+//                                .resizable()
+//                                .aspectRatio(contentMode: .fill)
+                            
+                            let url = perform.posterUrlList.isEmpty ? "" : perform.posterUrlList[0]
+                            
+                            AsyncImage(url: URL(string: url)) {image in
+                                image
+                                    .resizable()
+                                    .scaledToFill() // 이미지를 그리드 아이템에 맞게 채우기
+                                    //.frame(width: 100, height: 150) // 적절한 크기로 제한
+                                    //.clipped() //
+                            } placeholder: {
+                                ProgressView()
+                                    .foregroundStyle(.nineDarkGray)
+                                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            }
+                            .aspectRatio(contentMode: .fit)
+                            .clipped()
                             
                             LinearGradient(
                                 gradient: Gradient(colors: [Color.black.opacity(0.8), Color.black.opacity(0)]),
@@ -71,12 +91,16 @@ struct GenreView: View {
                             .frame(maxWidth: .infinity, alignment: .bottom)
                         }
                     }
+                    .onAppear{
+                        print("공연 개수 : \(filteredPerforms.count)")
+                    }
                 }
                 .padding(.top, 20)
   
             }
             .background(.nineBlack)
             .allowsHitTesting(!isModalPresented)
+            
             
             if isModalPresented {
                 Color.black.opacity(0.4)
@@ -101,5 +125,5 @@ extension GenreView {
 }
 
 #Preview {
-    GenreView(currentGenre: .constant(.All))
+    GenreView(currentGenre: .constant(.All), performs: .constant(Performance.performList))
 }

--- a/MaDang/MaDang/View/MainView/MainView.swift
+++ b/MaDang/MaDang/View/MainView/MainView.swift
@@ -8,19 +8,18 @@
 import SwiftUI
 
 struct MainView: View {
-    
     @State private var currentGenre: Genre = .All
     @State private var isModalPresented: Bool = false
-    let performs: [Performance] = Performance.performList
-    
+    @State private var performs: [Performance] = []
+
     var body: some View {
         NavigationStack{
             ScrollView {
                     VStack {
-                        WhatIsNewView()
+                        WhatIsNewView(performs: $performs)
                             .padding(.bottom, 8)
                         
-                        PopularityRankingView(performs: performs )
+                        PopularityRankingView(performs: performs)
                             .padding(.top, 16)
                             .border(.nineYellow)
                         
@@ -30,7 +29,21 @@ struct MainView: View {
                             .padding(.top, 64)
                     }
                     .border(.green)
-                .background(.nineBlack)
+                    .background(.nineBlack)
+            }
+            .onAppear {
+                let shared = KopisNetworkingManager.shared
+                // 임의 조건 설정
+                shared.fetchPerformList(startDate: "20240601", endDate: "20240631", row: 5, genreCode: Genre.Theater.code) { result in
+                     switch result {
+                     case .success(let performs) :
+                         print("success")
+                         self.performs = performs
+                         
+                     case .failure(_):
+                         print("failure")
+                     }
+                 }
             }
         }
     }

--- a/MaDang/MaDang/View/MainView/MainView.swift
+++ b/MaDang/MaDang/View/MainView/MainView.swift
@@ -19,11 +19,11 @@ struct MainView: View {
                         WhatIsNewView(performs: $performs)
                             .padding(.bottom, 8)
                         
-                        PopularityRankingView(performs: performs)
+                        PopularityRankingView(performs: $performs)
                             .padding(.top, 16)
                             .border(.nineYellow)
                         
-                        GenreView(currentGenre: $currentGenre)
+                        GenreView(currentGenre: $currentGenre, performs: $performs)
                             
                         BestReviewView()
                             .padding(.top, 64)
@@ -31,10 +31,11 @@ struct MainView: View {
                     .border(.green)
                     .background(.nineBlack)
             }
+            .background(.black)
             .onAppear {
                 let shared = KopisNetworkingManager.shared
                 // 임의 조건 설정
-                shared.fetchPerformList(startDate: "20240601", endDate: "20240631", row: 5, genreCode: Genre.Theater.code) { result in
+                shared.fetchPerformList(startDate: "20240601", endDate: "20240631", row: 9, genreCode: Genre.Theater.code) { result in
                      switch result {
                      case .success(let performs) :
                          print("success")

--- a/MaDang/MaDang/View/MainView/PopularityRankingView.swift
+++ b/MaDang/MaDang/View/MainView/PopularityRankingView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PopularityRankingView: View {
     
     // 랭킹 및 국가로 필터링 된 공연
-    let performs: [Performance]
+    @Binding var performs: [Performance]
     @State private var selection = 0
     
     var body: some View {
@@ -45,9 +45,9 @@ struct PopularityRankingView: View {
                         ForEach(performs.indices, id: \.self) { i in
                             VStack {
                                 NavigationLink {
-                                    DetailView()
+                                    DetailView(perform: $performs[i])
                                 } label: {
-                                    RankingCell(title: performs[i].title, rank: i + 1, imageUrl: "")
+                                    RankingCell(rank: i + 1, perform: $performs[i])
                                         .padding(.horizontal, 6)
                                 }
                                 
@@ -121,5 +121,5 @@ extension PopularityRankingView {
 }
 
 #Preview {
-    PopularityRankingView(performs: Performance.performList)
+    PopularityRankingView(performs: .constant(Performance.performList))
 }

--- a/MaDang/MaDang/View/MainView/RankingCell.swift
+++ b/MaDang/MaDang/View/MainView/RankingCell.swift
@@ -9,9 +9,8 @@ import SwiftUI
 
 struct RankingCell: View {
     
-    let title: String
     let rank: Int
-    let imageUrl: String
+    @Binding var perform: Performance
     
     var body: some View {
         let screenWidth = UIScreen.main.bounds.width
@@ -20,10 +19,21 @@ struct RankingCell: View {
         
         VStack{
             ZStack(alignment: .bottomLeading) {
-                Image("kopisTestImage")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: imageWidth, height: imageWidth * aspectRatio)
+                let url = perform.posterUrlList.isEmpty ? "" : perform.posterUrlList[0]
+//                Image("kopisTestImage")
+//                    .resizable()
+//                    .scaledToFit()
+//                    .frame(width: imageWidth, height: imageWidth * aspectRatio)
+                
+                AsyncImage(url: URL(string: url)) {image in
+                    image
+                        .resizable()
+                        .scaledToFit()
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: imageWidth, height: imageWidth * aspectRatio)
+                
                 Text("\(rank)")
                     .foregroundColor(Color.yellow.opacity(0.5))
                     .fontWeight(.bold)
@@ -31,7 +41,7 @@ struct RankingCell: View {
                     .offset(x: -20, y: 23)
             }
             
-            Text(title)
+            Text(perform.title)
                 .font(.system(size: 16))
                 .frame(width: 123)
                 .foregroundStyle(.gray)
@@ -43,5 +53,5 @@ struct RankingCell: View {
 }
 
 #Preview {
-    RankingCell(title: "A Store Selling Time", rank: 2, imageUrl: "url")
+    RankingCell(rank: 2, perform: .constant(Performance.performList[0]))
 }

--- a/MaDang/MaDang/View/MainView/WhatIsNewView.swift
+++ b/MaDang/MaDang/View/MainView/WhatIsNewView.swift
@@ -9,12 +9,11 @@ import SwiftUI
 
 struct WhatIsNewView: View {
     @State private var currentIndex: Int = 0
-    // @ObservedObject var dataManager: DataManager = DataManager.shared
     @Binding var performs: [Performance]
     
     var body: some View {
-       // let topPerformances = Array(dataManager.performs.prefix(4))
-        
+        let recentPerforms = Array(performs.sorted { $0.startDate > $1.startDate }.prefix(4))
+    
         VStack{
             HStack{
                 Text("What's new")
@@ -25,61 +24,66 @@ struct WhatIsNewView: View {
                 Spacer()
             }
             
-            CarouselView(currentIndex: $currentIndex, performs: $performs)
+            CarouselView(currentIndex: $currentIndex, performs: $performs, pageCount: recentPerforms.count)
                 .frame(height: UIScreen.main.bounds.height * 3/5)
                 .padding(.bottom, 10)
             
             
             PageIndicator(currentIndex: $currentIndex, pageCount: 4)
         }
+
         .background(.nineBlack)
         .border(.yellow)
     }
 }
 
 fileprivate struct CarouselView: View {
-  
+
     @GestureState var dragOffset: CGFloat = 0
     @Binding var currentIndex: Int
     @Binding var performs: [Performance]
-    
+    @State private var isDetailViewPresented: Bool = false
+    @State private var selectedPerform: Performance = Performance.performList[0]
+
     /// pageCount는 1 이상입니다.
-    let pageCount: Int = 4
+    let pageCount: Int
     let spacing: CGFloat = 0
     let visibleEdgeSpace: CGFloat = 20
-    
+
     var body: some View {
         let filtered = Array(performs.prefix(4))
-        
+
         GeometryReader { proxy in
-            
+
             /// 첫번째 요소의 왼쪽 여백입니다.
             let baseOffset: CGFloat = spacing + visibleEdgeSpace
-            
+
             /// 티켓 하나 width를 나타냅니다.
             let pageWidth: CGFloat = proxy.size.width - (visibleEdgeSpace + spacing) * 2
-            
+
             /// HStack에서 보여질 곳을 정합니다.
             let offsetX: CGFloat = baseOffset + CGFloat(currentIndex) * -pageWidth + CGFloat(currentIndex) * -spacing + dragOffset
-            
+
             HStack(spacing: spacing) {
-                ForEach(filtered.indices, id: \.self) { pageIndex in
-                    VStack{
-                        //Image("kopisTestImage")
-                        AsyncImage(url: URL(string: "")) {image in
+                ForEach(0..<pageCount, id: \.self) { index in
+                    let url = performs[index].posterUrlList.isEmpty ? "" : performs[index].posterUrlList[0]
+
+                    VStack {
+                        AsyncImage(url: URL(string: url)) { image in
                             image
                                 .resizable()
                                 .scaledToFit()
                         } placeholder: {
-                            // Progress View
+                            ProgressView()
                         }
-//                            .resizable()
-//                            .scaledToFit()
-                            .frame(width: pageWidth)
-                            .scaleEffect(scaleFor(index: pageIndex, pageWidth: pageWidth))
-                        // Text("\(pageIndex)")
+                        .frame(width: pageWidth)
+                        .scaleEffect(scaleFor(index: index, pageWidth: pageWidth))
+                        .onTapGesture {
+                            selectedPerform = performs[index]
+                            isDetailViewPresented = true
+                        }
                     }
-                    .frame(width: pageWidth) // 삭제
+                    .frame(width: pageWidth)
                 }
                 .contentShape(RoundedRectangle(cornerRadius: 20))
             }
@@ -95,7 +99,7 @@ fileprivate struct CarouselView: View {
                         let offsetX = value.translation.width
                         let progress = -offsetX / pageWidth
                         let increment = Int(progress.rounded())
-                        
+
                         currentIndex = max(min(currentIndex + increment, pageCount - 1), 0)
                     }
             )
@@ -103,8 +107,13 @@ fileprivate struct CarouselView: View {
             .animation(.easeInOut, value: dragOffset == 0)
         }
         .border(Color.blue)
+        .sheet(isPresented: $isDetailViewPresented) {
+                DetailView(perform: $selectedPerform)
+//                DetailView(perform: Binding(get: { selectedPerform }, set: { _ in }))
+            
+        }
     }
-    
+
     private func scaleFor(index: Int, pageWidth: CGFloat) -> CGFloat {
         let offset = CGFloat(index - currentIndex) * pageWidth + dragOffset
         let distanceFromCenter = abs(offset) / pageWidth
@@ -126,7 +135,4 @@ struct PageIndicator: View {
         }
     }
 }
-//
-//#Preview {
-//    WhatIsNewView()
-//}
+

--- a/MaDang/MaDang/View/MainView/WhatIsNewView.swift
+++ b/MaDang/MaDang/View/MainView/WhatIsNewView.swift
@@ -9,8 +9,12 @@ import SwiftUI
 
 struct WhatIsNewView: View {
     @State private var currentIndex: Int = 0
+    // @ObservedObject var dataManager: DataManager = DataManager.shared
+    @Binding var performs: [Performance]
     
     var body: some View {
+       // let topPerformances = Array(dataManager.performs.prefix(4))
+        
         VStack{
             HStack{
                 Text("What's new")
@@ -21,7 +25,7 @@ struct WhatIsNewView: View {
                 Spacer()
             }
             
-            CarouselView(currentIndex: $currentIndex)
+            CarouselView(currentIndex: $currentIndex, performs: $performs)
                 .frame(height: UIScreen.main.bounds.height * 3/5)
                 .padding(.bottom, 10)
             
@@ -34,9 +38,10 @@ struct WhatIsNewView: View {
 }
 
 fileprivate struct CarouselView: View {
-    
+  
     @GestureState var dragOffset: CGFloat = 0
     @Binding var currentIndex: Int
+    @Binding var performs: [Performance]
     
     /// pageCount는 1 이상입니다.
     let pageCount: Int = 4
@@ -44,6 +49,8 @@ fileprivate struct CarouselView: View {
     let visibleEdgeSpace: CGFloat = 20
     
     var body: some View {
+        let filtered = Array(performs.prefix(4))
+        
         GeometryReader { proxy in
             
             /// 첫번째 요소의 왼쪽 여백입니다.
@@ -56,12 +63,18 @@ fileprivate struct CarouselView: View {
             let offsetX: CGFloat = baseOffset + CGFloat(currentIndex) * -pageWidth + CGFloat(currentIndex) * -spacing + dragOffset
             
             HStack(spacing: spacing) {
-                ForEach(0..<pageCount, id: \.self) { pageIndex in
-                    
+                ForEach(filtered.indices, id: \.self) { pageIndex in
                     VStack{
-                        Image("kopisTestImage")
-                            .resizable()
-                            .scaledToFit()
+                        //Image("kopisTestImage")
+                        AsyncImage(url: URL(string: "")) {image in
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        } placeholder: {
+                            // Progress View
+                        }
+//                            .resizable()
+//                            .scaledToFit()
                             .frame(width: pageWidth)
                             .scaleEffect(scaleFor(index: pageIndex, pageWidth: pageWidth))
                         // Text("\(pageIndex)")
@@ -113,7 +126,7 @@ struct PageIndicator: View {
         }
     }
 }
-
-#Preview {
-    WhatIsNewView()
-}
+//
+//#Preview {
+//    WhatIsNewView()
+//}

--- a/MaDang/MaDang/View/RankingView/RankingModalView.swift
+++ b/MaDang/MaDang/View/RankingView/RankingModalView.swift
@@ -31,7 +31,6 @@ struct RankingModalView: View {
                         .background(Color.gray)
                         .padding(.vertical,16)
 
-                    
                     Button(action: {
                         withAnimation {
                             selectedRanking = ranking
@@ -39,25 +38,17 @@ struct RankingModalView: View {
                         }
                     }, label: {
                         VStack{
-                            
-                            
-                            
                             Text("\(ranking.rawValue)")
                                 .font(.callout)
                                 .foregroundStyle(.white)
-                                
-                            
                         }
                     })
                     
                 }
-                
             }.padding(.bottom, 16)
             .background(.nineDarkGray)
                 .cornerRadius(15)
-                
                 .padding(.horizontal,44)
-        
     }
 }
 


### PR DESCRIPTION
- http 이미지 https로 변경
- 메인뷰 데이터 연동
- 디테일뷰 데이터 연동
- 케러셀 dragGesture, NavigationLink 충돌로
   onTapGesture와 sheet 사용

- 우선 메인 화면에서 공연 목록을 받아온걸 기반으로 데이터 입력
- 추후 디테일뷰에 들어갈 때, 해당 ID 공연상세 정보를 요청해서 performs를 갱신하여 추가 정보를 채울 것

- 장르뷰 이미지 사이즈 충돌 해결

- 전체적으로 image가 url로 요청되는 경우가 많아 cache사용을 나중에 고려해볼만 할 듯