### PR TITLE
[Feat] #63 - AppleLogin 삭제, 일반 로그인 전환

### DIFF
--- a/MaDang/MaDang.xcodeproj/project.pbxproj
+++ b/MaDang/MaDang.xcodeproj/project.pbxproj
@@ -42,16 +42,14 @@
 		33388DF62C720F3300DECDC3 /* GPTManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DF52C720F3300DECDC3 /* GPTManager.swift */; };
 		33388DF92C720F5700DECDC3 /* ChatGPTSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 33388DF82C720F5700DECDC3 /* ChatGPTSwift */; };
 		33388DFB2C720F5700DECDC3 /* SampleApp in Frameworks */ = {isa = PBXBuildFile; productRef = 33388DFA2C720F5700DECDC3 /* SampleApp */; };
-		33388DFD2C72149E00DECDC3 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DFC2C72149E00DECDC3 /* DataManager.swift */; };
 		33388DFF2C7226D900DECDC3 /* DetailXMLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */; };
 		33388E012C72827300DECDC3 /* ReviewEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388E002C72827300DECDC3 /* ReviewEditorView.swift */; };
 		33388E052C728B7F00DECDC3 /* RatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388E042C728B7F00DECDC3 /* RatingView.swift */; };
 		33388E072C732F6900DECDC3 /* FocusableTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33388E062C732F6900DECDC3 /* FocusableTextEditor.swift */; };
+		334FE8602C78D4B400A5404E /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334FE85F2C78D4B400A5404E /* RegisterView.swift */; };
+		334FE8622C78FD6400A5404E /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334FE8612C78FD6400A5404E /* LoginView.swift */; };
 		33A068982C73B79200EF0F09 /* TouristInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A068972C73B79200EF0F09 /* TouristInfoCell.swift */; };
 		33A0689A2C73C1AD00EF0F09 /* TouristInfoGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A068992C73C1AD00EF0F09 /* TouristInfoGridView.swift */; };
-		33A068A02C74797C00EF0F09 /* AppleAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A0689F2C74797C00EF0F09 /* AppleAuthManager.swift */; };
-		33A068A22C74799800EF0F09 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A068A12C74799800EF0F09 /* KeychainHelper.swift */; };
-		33A068A52C7479F800EF0F09 /* AppleLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A068A42C7479F800EF0F09 /* AppleLoginView.swift */; };
 		33A068A82C747BB300EF0F09 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 33A068A72C747BB300EF0F09 /* FirebaseAnalytics */; };
 		33A068AA2C747BB300EF0F09 /* FirebaseAnalyticsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = 33A068A92C747BB300EF0F09 /* FirebaseAnalyticsOnDeviceConversion */; };
 		33A068AC2C747BB300EF0F09 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 33A068AB2C747BB300EF0F09 /* FirebaseAnalyticsWithoutAdIdSupport */; };
@@ -148,17 +146,15 @@
 		33388DEA2C713C6900DECDC3 /* ApiModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiModel.swift; sourceTree = "<group>"; };
 		33388DEC2C713E5C00DECDC3 /* XMLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLParser.swift; sourceTree = "<group>"; };
 		33388DF52C720F3300DECDC3 /* GPTManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTManager.swift; sourceTree = "<group>"; };
-		33388DFC2C72149E00DECDC3 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailXMLParser.swift; sourceTree = "<group>"; };
 		33388E002C72827300DECDC3 /* ReviewEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewEditorView.swift; sourceTree = "<group>"; };
 		33388E042C728B7F00DECDC3 /* RatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingView.swift; sourceTree = "<group>"; };
 		33388E062C732F6900DECDC3 /* FocusableTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusableTextEditor.swift; sourceTree = "<group>"; };
+		334FE85F2C78D4B400A5404E /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
+		334FE8612C78FD6400A5404E /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		33A068972C73B79200EF0F09 /* TouristInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouristInfoCell.swift; sourceTree = "<group>"; };
 		33A068992C73C1AD00EF0F09 /* TouristInfoGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouristInfoGridView.swift; sourceTree = "<group>"; };
 		33A0689C2C7464C300EF0F09 /* MaDang.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MaDang.entitlements; sourceTree = "<group>"; };
-		33A0689F2C74797C00EF0F09 /* AppleAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthManager.swift; sourceTree = "<group>"; };
-		33A068A12C74799800EF0F09 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
-		33A068A42C7479F800EF0F09 /* AppleLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginView.swift; sourceTree = "<group>"; };
 		33A068DB2C7518AC00EF0F09 /* FirestoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreManager.swift; sourceTree = "<group>"; };
 		33DF50682C77B1F300D0A5C1 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		4665F0D72C7208E5007867FB /* RankingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingView.swift; sourceTree = "<group>"; };
@@ -284,16 +280,18 @@
 		33388D7E2C6F34E200DECDC3 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				4665F0ED2C723802007867FB /* MainTabView.swift */,
 				46C62C7E2C78489900357422 /* Translate */,
 				33A068A32C7479E900EF0F09 /* LoginView */,
 				468EEED32C73B34700C07488 /* AccountView */,
-				4665F0ED2C723802007867FB /* MainTabView.swift */,
 				33A0689B2C73D13800EF0F09 /* ReviewEditorView */,
 				4665F1222C73AFEA007867FB /* ByGenreView */,
 				4665F0D62C7208D2007867FB /* RankingView */,
 				33388DBB2C7085A700DECDC3 /* MainView */,
 				33388D822C6F362B00DECDC3 /* DetailView */,
 				33388D712C6F2C0A00DECDC3 /* ContentView.swift */,
+				334FE85F2C78D4B400A5404E /* RegisterView.swift */,
+				334FE8612C78FD6400A5404E /* LoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -314,7 +312,6 @@
 				33388D902C6F635300DECDC3 /* Color+.swift */,
 				33388DEC2C713E5C00DECDC3 /* XMLParser.swift */,
 				33388DFE2C7226D900DECDC3 /* DetailXMLParser.swift */,
-				33A068A12C74799800EF0F09 /* KeychainHelper.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -391,8 +388,6 @@
 			children = (
 				33388DE12C712E3800DECDC3 /* KopisNetworkingManager.swift */,
 				33388DF52C720F3300DECDC3 /* GPTManager.swift */,
-				33388DFC2C72149E00DECDC3 /* DataManager.swift */,
-				33A0689F2C74797C00EF0F09 /* AppleAuthManager.swift */,
 				33A068DB2C7518AC00EF0F09 /* FirestoreManager.swift */,
 				33DF50682C77B1F300D0A5C1 /* UserManager.swift */,
 			);
@@ -412,7 +407,6 @@
 		33A068A32C7479E900EF0F09 /* LoginView */ = {
 			isa = PBXGroup;
 			children = (
-				33A068A42C7479F800EF0F09 /* AppleLoginView.swift */,
 			);
 			path = LoginView;
 			sourceTree = "<group>";
@@ -576,7 +570,6 @@
 				33388D722C6F2C0A00DECDC3 /* ContentView.swift in Sources */,
 				4665F0E22C721C22007867FB /* RankingListView.swift in Sources */,
 				33DF50692C77B1F300D0A5C1 /* UserManager.swift in Sources */,
-				33388DFD2C72149E00DECDC3 /* DataManager.swift in Sources */,
 				468EEED52C73B35A00C07488 /* AccountView.swift in Sources */,
 				46C62C692C77A36800357422 /* MainHeader.swift in Sources */,
 				33388DE92C71324100DECDC3 /* Bundle+.swift in Sources */,
@@ -586,6 +579,7 @@
 				33388DC52C70867500DECDC3 /* BestReviewView.swift in Sources */,
 				4665F0DC2C720BAB007867FB /* Ranking.swift in Sources */,
 				33388D912C6F635300DECDC3 /* Color+.swift in Sources */,
+				334FE8602C78D4B400A5404E /* RegisterView.swift in Sources */,
 				4665F0DA2C7209A0007867FB /* LogoHeader.swift in Sources */,
 				33A068982C73B79200EF0F09 /* TouristInfoCell.swift in Sources */,
 				4665F12C2C73B0B2007867FB /* ByGenreViewModel.swift in Sources */,
@@ -624,21 +618,19 @@
 				33388D962C6F88F900DECDC3 /* Performance.swift in Sources */,
 				46C62C772C78090100357422 /* TextAndTranslateManager.swift in Sources */,
 				468EEEDD2C73C45D00C07488 /* LikesView.swift in Sources */,
-				33A068A22C74799800EF0F09 /* KeychainHelper.swift in Sources */,
 				33388DB42C6FCC5F00DECDC3 /* Country.swift in Sources */,
 				4665F0D82C7208E5007867FB /* RankingView.swift in Sources */,
 				468EEEDB2C73C05900C07488 /* CommunityList.swift in Sources */,
 				4665F1282C73B062007867FB /* ByGenreModalView.swift in Sources */,
 				46C62C7D2C78096800357422 /* ImageWithOverlayView.swift in Sources */,
-				33A068A02C74797C00EF0F09 /* AppleAuthManager.swift in Sources */,
 				468EEED72C73B4EC00C07488 /* AccountProfile.swift in Sources */,
 				33388DB82C6FCE0700DECDC3 /* AttractionType.swift in Sources */,
 				46C62C732C77BC8300357422 /* TextDetectionViewModel.swift in Sources */,
 				46C62C712C77BBF300357422 /* TranslateViewModel.swift in Sources */,
+				334FE8622C78FD6400A5404E /* LoginView.swift in Sources */,
 				33388DC12C70865A00DECDC3 /* PopularityRankingView.swift in Sources */,
 				33388E072C732F6900DECDC3 /* FocusableTextEditor.swift in Sources */,
 				33388D8D2C6F368300DECDC3 /* DetailTouristInfoView.swift in Sources */,
-				33A068A52C7479F800EF0F09 /* AppleLoginView.swift in Sources */,
 				33388D842C6F363800DECDC3 /* DetailView.swift in Sources */,
 				33388E012C72827300DECDC3 /* ReviewEditorView.swift in Sources */,
 				33388D702C6F2C0A00DECDC3 /* MaDangApp.swift in Sources */,

--- a/MaDang/MaDang/App/MaDangApp.swift
+++ b/MaDang/MaDang/App/MaDangApp.swift
@@ -8,79 +8,52 @@
 import SwiftUI
 import FirebaseCore
 import FirebaseAuth
+import AuthenticationServices
 
 class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    FirebaseApp.configure()
-
-    return true
-  }
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        // Firebase 초기화
+        FirebaseApp.configure()
+        
+        return true
+    }
 }
 
 @main
 struct MaDangApp: App {
     @State private var performs: [Performance] = []
+    //@State private var isUserLoggedIn = false
+        
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    @StateObject private var authManager: AppleAuthManager = AppleAuthManager()
     @StateObject private var userManager: UserManager = UserManager()
-    
-    var userId: String {
-           return Auth.auth().currentUser?.uid ?? "Unknown User"
-       }
     
     var body: some Scene {
         WindowGroup {
-//            GPTTestView()
-            MainTabView(performs: $performs)
-                .environmentObject(authManager)
-                .environmentObject(userManager)
-                .onAppear {
-                    let shared = KopisNetworkingManager.shared
-                    // 임의 조건 설정
-                    //shared.fetchPerformList(startDate: "20240601", endDate: "20240831", row: 20, genreCode: Genre.Theater.code) { result in
-                    shared.fetchPerformList(startDate: "20240801", endDate: "20240831", row: 20) { result in
-                         switch result {
-                         case .success(let performs) :
-                             print("success")
-                             self.performs = performs
-                             
-                         case .failure(_):
-                             print("failure")
-                         }
-                     }
-                    
-                    // User 생성
-                    let newUser = User(
-                        id: userId,  // 사용자가 직접 설정한 ID
-                        name: "Andrew",
-                        country: .KOR,
-                        reviewIdList: [],
-                        likeReviewIdList: [],
-                        likePerformIdList: []
-                    )
+            NavigationStack{
+                if !userManager.isUserLoggedIn {
+                    LoginView()
+                } else {
+                    MainTabView(performs: $performs)
+                        .onAppear {
+                            let shared = KopisNetworkingManager.shared
 
-                    FirestoreManager.shared.createUser(newUser) { result in
-                        switch result {
-                        case .success():
-                            print("User created successfully.")
-                        case .failure(let error):
-                            print("Failed to create user: \(error.localizedDescription)")
+                            shared.fetchPerformList(startDate: "20240801", endDate: "20240831", row: 20) { result in
+                                switch result {
+                                case .success(let performs) :
+                                    print("success")
+                                    self.performs = performs
+                                    
+                                case .failure(_):
+                                    print("failure")
+                                }
+                            }
+
                         }
-                    }
-                    
-                    // User 일단 더미 설정
-                    FirestoreManager.shared.fetchUserById(userId: userId) { result in
-                        switch result {
-                        case .success(let user) :
-                            userManager.user = user
-                            print("Set user success")
-                        case .failure(_):
-                            userManager.user?.name = "Unknowned"
-                            print("Set user failure")
-                        }
-                    }
                 }
+            }
+            .environmentObject(userManager)
         }
     }
+    
 }

--- a/MaDang/MaDang/Helper/XMLParser.swift
+++ b/MaDang/MaDang/Helper/XMLParser.swift
@@ -69,7 +69,7 @@ final class MyXMLParser: NSObject, XMLParserDelegate {
         currentValue = ""
     }
     
-    // 파싱이 완료되었을 때 호출되는 메서드 (테스트용)
+     // 파싱이 완료되었을 때 호출되는 메서드 (테스트용)
     func parserDidEndDocument(_ parser: XMLParser) {
         let dbs = Dbs(script: script, db: dbList)
         welcome4 = Welcome4(dbs: dbs)

--- a/MaDang/MaDang/Manager/FirestoreManager.swift
+++ b/MaDang/MaDang/Manager/FirestoreManager.swift
@@ -1,14 +1,15 @@
 import Foundation
 import FirebaseFirestore
+import FirebaseAuth
 
 final class FirestoreManager: ObservableObject {
     @Published var reviews: [Review] = []
 
     private var db = Firestore.firestore()
-
     static let shared = FirestoreManager()
     private init() {}
 
+    
     // MARK: - 리뷰 등록
     func addReview(performanceId: String, writerId: String, writerCountry: Country, writerName: String, content: String, starRating: Double, completion: @escaping (Result<Void, Error>) -> Void) {
         let newReview = Review(

--- a/MaDang/MaDang/Manager/UserManager.swift
+++ b/MaDang/MaDang/Manager/UserManager.swift
@@ -1,14 +1,50 @@
-//
-//  UserManager.swift
-//  MaDang
-//
-//  Created by LDW on 8/23/24.
-//
-
 import Foundation
+import FirebaseAuth
 
 final class UserManager: ObservableObject {
     @Published var user: User?
+    @Published var fUser: FirebaseAuth.User?
+    @Published var isUserLoggedIn: Bool = false // @Published로 선언하여 상태 변경 시 뷰 업데이트
+
+    init() {
+        checkLoginStatus()
+    }
+    
+    func checkLoginStatus() {
+        if let currentUser = Auth.auth().currentUser {
+            // 사용자가 로그인되어 있음
+            self.fUser = currentUser
+            self.isUserLoggedIn = true
+        } else {
+            // 사용자가 로그인되어 있지 않음
+            self.user = nil
+            self.isUserLoggedIn = false
+        }
+    }
+    
+    func loginUser(email: String, password: String, completion: @escaping (Bool) -> Void) {
+        Auth.auth().signIn(withEmail: email, password: password) { [weak self] authResult, error in
+            if let error = error {
+                print("Login Error: \(error.localizedDescription)")
+                completion(false)
+            } else if let user = authResult?.user {
+                self?.fUser = user
+                self?.isUserLoggedIn = true
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
+    
+    func logoutUser() {
+        do {
+            try Auth.auth().signOut()
+            self.fUser = nil
+            self.isUserLoggedIn = false
+        } catch {
+            print("Logout Error: \(error.localizedDescription)")
+        }
+    }
     
 }
-

--- a/MaDang/MaDang/View/AccountView/AccountView.swift
+++ b/MaDang/MaDang/View/AccountView/AccountView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct AccountView: View {
-    @EnvironmentObject var authManager: AppleAuthManager
-    
+
     var body: some View {
         ZStack {
             ScrollView {
@@ -22,8 +21,7 @@ struct AccountView: View {
                 CommunityList()
                 
                 Button {
-                    KeychainHelper.shared.deleteUserIdentifier()
-                    authManager.authState = .signedOut
+                   
                 } label: {
                     Text("로그아웃")
                 }

--- a/MaDang/MaDang/View/LoginView.swift
+++ b/MaDang/MaDang/View/LoginView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import FirebaseAuth
+
+struct LoginView: View {
+    @EnvironmentObject var userManager: UserManager
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var errorMessage: String = ""
+    @State private var showingAlert = false
+    @State private var navigateToRegister = false
+
+    var body: some View {
+        VStack {
+            Text("Login")
+                .font(.largeTitle)
+                .padding()
+
+            TextField("Enter your email", text: $email)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+
+            SecureField("Enter your password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+
+            Button(action: {
+                loginUser()
+            }) {
+                Text("Login")
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(10)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding()
+
+            Button(action: {
+                navigateToRegister = true
+            }) {
+                Text("Register")
+                    .foregroundColor(.blue)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.bottom)
+
+            .alert(isPresented: $showingAlert) {
+                Alert(title: Text("Login Error"), message: Text(errorMessage), dismissButton: .default(Text("OK")))
+            }
+        }
+        .padding()
+        .background(
+            NavigationLink(
+                destination: RegisterView(),
+                isActive: $navigateToRegister,
+                label: { EmptyView() }
+            )
+        )
+    }
+
+    func loginUser() {
+        userManager.loginUser(email: email, password: password) { success in
+            if !success {
+                self.errorMessage = "Login failed. Please check your email and password."
+                self.showingAlert = true
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LoginView()
+            .environmentObject(UserManager())
+    }
+}

--- a/MaDang/MaDang/View/MainTabView.swift
+++ b/MaDang/MaDang/View/MainTabView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct MainTabView: View {
     @State private var selectedTab: Int = 0
     @Binding var performs: [Performance]
-    @EnvironmentObject var authManager: AppleAuthManager
+
     //    init() {
     //            UITabBar.appearance().backgroundColor = UIColor.black
     //            UITabBar.appearance().barTintColor = UIColor.black
@@ -18,12 +18,7 @@ struct MainTabView: View {
     
     
     var body: some View {
-        VStack{
-            if authManager.authState == .signedOut {
-                
-                AppleLoginView()
-            } else {
-                
+
                 TabView(selection: $selectedTab) {
                     MainView(performs: $performs)
                         .tabItem {
@@ -59,11 +54,6 @@ struct MainTabView: View {
                     UITabBar.appearance().backgroundColor = UIColor.black
                     UITabBar.appearance().barTintColor = UIColor.black
                 }
-            }
-        }
-        .onAppear {
-            authManager.checkForExistingUser()
-        }
     }
 }
 

--- a/MaDang/MaDang/View/MainView/MainView.swift
+++ b/MaDang/MaDang/View/MainView/MainView.swift
@@ -6,14 +6,15 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 struct MainView: View {
+    @EnvironmentObject var userManager: UserManager
     @State private var currentGenre: Genre = .All
     @State private var isModalPresented: Bool = false
     @State private var isLangModalPresented: Bool = false
     @State private var currentLang: Language = .Korean
     @Binding var performs: [Performance]
-    
 
     var body: some View {
         NavigationStack{
@@ -22,9 +23,7 @@ struct MainView: View {
                     VStack {
                         
                         MainHeader(currentLang: $currentLang, isLangModalPresented: $isLangModalPresented)
-                        
-                        
-                        
+
                         WhatIsNewView(performs: $performs)
                             .padding(.bottom, 8)
                         
@@ -36,6 +35,18 @@ struct MainView: View {
                         
                         BestReviewView()
                             .padding(.top, 64)
+                        
+                        Button {
+                            userManager.logoutUser()
+                            do {
+                                try Auth.auth().signOut()
+                            } catch let signOutError as NSError {
+                              print ("Error signing out: %@", signOutError)
+                            }
+                        } label: {
+                            Text("로그아웃")
+                        }
+                        
                     }
                     .border(.green)
                     .background(.nineBlack)

--- a/MaDang/MaDang/View/RegisterView.swift
+++ b/MaDang/MaDang/View/RegisterView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
+
+struct RegisterView: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var confirmPassword: String = ""
+    @State private var emailValidationMessage: String = ""
+    @State private var passwordValidationMessage: String = ""
+    @State private var confirmPasswordMessage: String = ""
+    @State private var errorMessage: String = ""
+    @State private var showingAlert = false
+
+    var body: some View {
+        VStack {
+            Text("Register")
+                .font(.largeTitle)
+                .padding()
+
+            TextField("Enter your email", text: $email)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+                .onChange(of: email) { _ in
+                    self.emailValidationMessage = validateEmail() ? "Email is valid" : "Please enter a valid email address."
+                }
+
+            Text(emailValidationMessage)
+                .foregroundColor(validateEmail() ? .green : .red)
+                .padding(.horizontal)
+
+            SecureField("Enter your password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+                .onChange(of: password) { _ in
+                    self.passwordValidationMessage = validatePassword() ? "Password is valid" : "Password must be at least 8 characters long, containing at least one letter, one number, and one special character."
+                }
+
+            Text(passwordValidationMessage)
+                .foregroundColor(validatePassword() ? .green : .red)
+                .padding(.horizontal)
+
+            SecureField("Confirm your password", text: $confirmPassword)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+                .onChange(of: confirmPassword) { _ in
+                    self.confirmPasswordMessage = passwordsMatch() ? "Passwords match" : "Passwords do not match."
+                }
+
+            Text(confirmPasswordMessage)
+                .foregroundColor(passwordsMatch() ? .green : .red)
+                .padding(.horizontal)
+
+            Button(action: registerUser) {
+                Text("Register")
+                    .foregroundColor(.white)
+                    .padding()
+                    .background(Color.blue)
+                    .cornerRadius(10)
+                    .frame(maxWidth: .infinity)
+            }
+            .disabled(!canRegister())
+            .opacity(canRegister() ? 1 : 0.5)
+            .padding()
+
+            .alert(isPresented: $showingAlert) {
+                Alert(title: Text("Registration Error"), message: Text(errorMessage), dismissButton: .default(Text("OK")))
+            }
+        }
+        .padding()
+    }
+
+    func registerUser() {
+          guard canRegister() else { return }
+
+          Auth.auth().createUser(withEmail: email, password: password) { authResult, error in
+              DispatchQueue.main.async {
+                  if let error = error {
+                      self.errorMessage = error.localizedDescription
+                      self.showingAlert = true
+                  } else if let authResult = authResult {
+                      // Registration successful, now save the user data to Firestore
+                      saveUserToFirestore(uid: authResult.user.uid)
+                  }
+              }
+          }
+      }
+
+      func saveUserToFirestore(uid: String) {
+          let db = Firestore.firestore()
+          
+          let user = User(
+              id: uid,
+              name: email, // Assuming you're using email as the user's name, customize as needed
+              country: Country.ALL, // Replace with the actual value or input from the user
+              reviewIdList: [],
+              likeReviewIdList: [],
+              likePerformIdList: []
+          )
+
+          do {
+              try db.collection("users").document(uid).setData(from: user) { error in
+                  if let error = error {
+                      self.errorMessage = "Error saving user data: \(error.localizedDescription)"
+                      self.showingAlert = true
+                  } else {
+                      self.presentationMode.wrappedValue.dismiss()
+                      print("User registered and data saved to Firestore successfully!")
+                  }
+              }
+          } catch let error {
+              self.errorMessage = "Error saving user data: \(error.localizedDescription)"
+              self.showingAlert = true
+          }
+      }
+
+    func validateEmail() -> Bool {
+        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}$"
+        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+    }
+
+    func validatePassword() -> Bool {
+        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$#!%*?&])[A-Za-z\\d$@$#!%*?&]{8,}$"
+        return NSPredicate(format: "SELF MATCHES %@", passwordRegex).evaluate(with: password)
+    }
+
+    func passwordsMatch() -> Bool {
+        return password == confirmPassword && !password.isEmpty
+    }
+
+    func canRegister() -> Bool {
+        return validateEmail() && validatePassword() && passwordsMatch()
+    }
+}
+
+struct RegisterView_Previews: PreviewProvider {
+    static var previews: some View {
+        RegisterView()
+    }
+}


### PR DESCRIPTION
 AppleLogin 삭제
일반 로그인 전환
- 로그인, 회원가입 화면 (기본 기능만)
- userManager를 통한 유저 상태 관리
- Firestore에 user 저장